### PR TITLE
Add dependencies to classpath for Javadoc generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,15 @@
 # android-example
 
-[![Release](https://img.shields.io/github/release/jitpack/android-example.svg?label=maven version)](https://jitpack.io/#jitpack/android-example)
+[![Release](https://img.shields.io/github/release/jitpack/android-example.svg?label=Jitpack)](https://jitpack.io/#jitpack/android-example)
 
-Example Android library project that works with jitpack.io. The 
-See also the guide for [building Android projects](https://github.com/jitpack/jitpack.io/blob/master/ANDROID.md)
+Example Android library project that works with jitpack.io.
+Also see the guide for [building Android projects](https://github.com/jitpack/jitpack.io/blob/master/ANDROID.md)
 
-https://jitpack.io/#jitpack/android-example/1.0.2
+https://jitpack.io/#jitpack/android-example
 
 Add it to your build.gradle with:
 ```gradle
 repositories {
-    jcenter()
     maven { url "https://jitpack.io" }
 }
 ```
@@ -18,7 +17,7 @@ and:
 
 ```gradle
 dependencies {
-    compile 'com.github.jitpack:android-example:1.0.2'
+    compile 'com.github.jitpack:android-example:{latest version}'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:1.3.1'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Sun Dec 13 15:17:37 PST 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.9-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -33,6 +33,7 @@ task javadoc(type: Javadoc) {
     failOnError  false
     source = android.sourceSets.main.java.sourceFiles
     classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
+    classpath += configurations.compile
 }
 
 // build a jar with javadoc

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven' // ADD THIS
 
 android {
-    compileSdkVersion 21
-    buildToolsVersion "21.1.2"
+    compileSdkVersion 23
+    buildToolsVersion "23.0.2"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 23
         versionCode 1
         versionName "1.0"
     }

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,9 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.jitpack.example.examplelib">
-
-    <application android:allowBackup="true" android:label="@string/app_name"
-        android:icon="@drawable/ic_launcher" android:theme="@style/AppTheme">
-
-    </application>
+<manifest package="io.jitpack.example.examplelib">
 
 </manifest>


### PR DESCRIPTION
This will fix all the warnings during Javadoc generation when using other libraries.