### PR TITLE
improve usage of proguard rules

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,12 +12,7 @@ android {
         targetSdkVersion 23
         versionCode 1
         versionName "1.0"
-    }
-    buildTypes {
-        release {
-            minifyEnabled false
-            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
-        }
+        consumerProguardFiles 'proguard-rules.pro'
     }
 }
 


### PR DESCRIPTION
See the javadoc of consumerProguardFiles:

>Adds proguard rule files to be included in the published AAR.
This proguard rule file will then be used by any application project that consume the AAR (if proguard is enabled).
This allows AAR to specify shrinking or obfuscation exclude rules.
This is only valid for Library project. This is ignored in Application project.