### PR TITLE
use a plugin for the sources and javadoc jars

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,12 @@
 buildscript {
     repositories {
         jcenter()
-        maven { url "https://jitpack.io" }
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
-        classpath 'io.freefair:android-gradle-plugins:2.1.2'
+        classpath 'io.freefair.gradle:android-gradle-plugins:2.2.3'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
-        classpath 'io.freefair:android-gradle-plugins:2.0.0'
+        classpath 'io.freefair:android-gradle-plugins:2.1.2'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,10 +3,12 @@
 buildscript {
     repositories {
         jcenter()
+        maven { url "https://jitpack.io" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:2.0.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.3'
+        classpath 'io.freefair:android-gradle-plugins:2.0.0'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,29 +20,8 @@ dependencies {
     // add dependencies here
 }
 
-// build a jar with source files
-task sourcesJar(type: Jar) {
-    from android.sourceSets.main.java.srcDirs
-    classifier = 'sources'
-}
-
-task javadoc(type: Javadoc) {
-    failOnError  false
-    source = android.sourceSets.main.java.sourceFiles
-    classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-    classpath += configurations.compile
-}
-
-// build a jar with javadoc
-task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
-    from javadoc.destinationDir
-}
-
-artifacts {
-    archives sourcesJar
-    archives javadocJar
-}
+//sources and javadoc jars
+apply plugin: "io.freefair.android-maven-jars"
 
 // uncomment to build a jar file in addition to the default aar file
 //android.libraryVariants.all { variant ->


### PR DESCRIPTION
this makes the build.gradle shorter and improves the javadoc generation
